### PR TITLE
don't use `self`

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,12 +1,12 @@
-/* globals self */
+/* globals requirejs, require */
 
 export default function requireModule(module, exportName = 'default') {
-  let rjs = self.requirejs;
+  let rjs = requirejs;
 
   if (
     (rjs.has && rjs.has(module)) ||
     (!rjs.has && (rjs.entries[module] || rjs.entries[`${module}/index`]))
   ) {
-    return self.require(module)[exportName];
+    return require(module)[exportName];
   }
 }


### PR DESCRIPTION
Reaching out to the window for these objects can cause conflicts.

Our app wraps `vendor.js` in an IFFE so these globals are aren't clobbered by offending third-party scripts. So `requirejs`, `define`, and `require` are all available in context, but not explicitly available on the window.

I'm hoping this edit can be merged in, since it shouldn't cause conflicts with upstream consumers.