### PR TITLE
Simplify implementation.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,12 +1,7 @@
-/* globals requirejs, require */
+import require from 'require';
 
 export default function requireModule(module, exportName = 'default') {
-  let rjs = requirejs;
-
-  if (
-    (rjs.has && rjs.has(module)) ||
-    (!rjs.has && (rjs.entries[module] || rjs.entries[`${module}/index`]))
-  ) {
+  if (require.has(module)) {
     return require(module)[exportName];
   }
 }


### PR DESCRIPTION
loader.js provides a `require` module that can be used to:

* avoid globals usage
* avoid hard coding the `/index` fallback

This has been present since loader.js@4.0.3 which was released around 2 years ago...